### PR TITLE
Added support for Dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.github
+.vscode
+.eslintignore
+.eslintrc.json
+.gitignore
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+LICENSE.md
+docker-compose.yml
+README.md
+package-lock.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
-    version: '3'
-    services:
-     bot:
-      build: .
-      restart: always
+version: '3'
+
+volumes:
+    mongo_persist:
+services:
+    mongo:
+        image: mongo
+        container_name: db
+        volumes:
+            - mongo_persist:/data/db
+        environment:
+            - MONGO_INITDB_ROOT_USERNAME=root
+            - MONGO_INITDB_ROOT_PASSWORD=root
+            - MONGO_INITDB_DATABASE=heptagram
+        restart: always
+    bot:
+        container_name: bot
+        build: .
+        restart: always

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/Heptagram-Bot/Heptagram#readme",
   "dependencies": {
     "chalk": "^4.1.1",
+    "common-tags": "^1.8.0",
     "discord.js": "^13.0.0",
     "leo-profanity": "^1.3.0",
     "mathjs": "^9.3.2",


### PR DESCRIPTION
# Pull Request
_Hacktoberfest Tag Requested_
## Description

Adds support for Heptagram to be run in a Dockerized format, utilizing two containers, `bot`, and `db`(MongoDB instance).
Make sure to not open ports for `db`, as it's authentication is lax, to allow for ease of use, since it shouldn't be exposed to the open internet anyway.

## Related Issue

N/A, personal request.

## Scope

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation

For _any_ version updates, please verify if the documentation page needs an update. If it does, please create an issue to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
